### PR TITLE
Add local manuscript manager with JSON prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,86 @@
 # knowledge-waffle
-This is the personal manager to handle academic manuscript and others
+
+Simple local manager for academic manuscripts. Entries are stored in a JSON file
+and can be added, edited, deleted and filtered.
+
+## Installation
+
+The app uses the Python standard library. To run the tests you will need
+`pytest`:
+
+```bash
+pip install pytest
+```
+
+## Usage
+
+Generate the JSON prompt for obtaining `methods`, `datasets` and `metrics`
+information from ChatGPT:
+
+```bash
+python app.py prompt
+```
+
+Add a manuscript (details are optional JSON from the prompt output):
+
+```bash
+python app.py add --title "My Paper" --authors "Alice,Bob" \
+  --affiliations "Uni A,Uni B" --abstract "Short" --details details.json
+```
+
+Edit or delete entries by index:
+
+```bash
+python app.py edit 0 --title "Updated Title"
+python app.py delete 0
+```
+
+List entries or available models/datasets/metrics:
+
+```bash
+python app.py list
+python app.py fields
+```
+
+Filter entries:
+
+```bash
+python app.py filter --model MODEL_NAME
+python app.py filter --dataset DATASET_NAME
+python app.py filter --metric METRIC_NAME
+```
+
+The generated prompt asks ChatGPT to return JSON with the following structure:
+
+```json
+{
+  "instruction": "Given the text of an academic manuscript, extract structured information.",
+  "fields": {
+    "methods": [{
+      "model_name": "",
+      "type": "LLM | VLM | Image",
+      "embedding_size": "integer",
+      "backbone": "",
+      "parameters": "integer"
+    }],
+    "datasets": [{
+      "name": "",
+      "usage": "training | finetuning | evaluation",
+      "focus": "main purpose or domain",
+      "sample_type": "QA pair | long text | medical EHR | report | other",
+      "is_public": "true | false",
+      "num_samples": "integer"
+    }],
+    "metrics": [{
+      "name": "",
+      "evaluation_type": "multiple choice | QA | other",
+      "value": "number",
+      "description": "how the metric is calculated",
+      "model_name": "associated model"
+    }]
+  }
+}
+```
+
+The JSON returned by ChatGPT can be saved to a file and supplied to `--details`
+when adding or editing an entry.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,99 @@
+import argparse
+import json
+from typing import Any, Dict
+
+from manuscripts import ManuscriptDB, generate_prompt
+
+def load_details(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manuscript manager")
+    sub = parser.add_subparsers(dest="command")
+
+    # Prompt generator
+    sub.add_parser("prompt", help="Show JSON prompt for ChatGPT")
+
+    # Add entry
+    add_p = sub.add_parser("add", help="Add a manuscript")
+    add_p.add_argument("--title", required=True)
+    add_p.add_argument("--authors", required=True, help="Comma separated")
+    add_p.add_argument("--affiliations", required=True, help="Comma separated")
+    add_p.add_argument("--abstract", required=True)
+    add_p.add_argument("--details", help="Path to JSON file containing methods/datasets/metrics")
+
+    # Edit entry
+    edit_p = sub.add_parser("edit", help="Edit an entry")
+    edit_p.add_argument("index", type=int)
+    edit_p.add_argument("--title")
+    edit_p.add_argument("--authors")
+    edit_p.add_argument("--affiliations")
+    edit_p.add_argument("--abstract")
+    edit_p.add_argument("--details", help="Path to JSON file with methods/datasets/metrics")
+
+    # Delete entry
+    del_p = sub.add_parser("delete", help="Delete an entry")
+    del_p.add_argument("index", type=int)
+
+    # List entries
+    sub.add_parser("list", help="List entries")
+
+    # List fields
+    sub.add_parser("fields", help="List all models, datasets and metrics")
+
+    # Filter entries
+    filt_p = sub.add_parser("filter", help="Filter entries")
+    filt_p.add_argument("--model")
+    filt_p.add_argument("--dataset")
+    filt_p.add_argument("--metric")
+
+    args = parser.parse_args()
+    db = ManuscriptDB()
+
+    if args.command == "prompt":
+        print(generate_prompt())
+    elif args.command == "add":
+        entry: Dict[str, Any] = {
+            "title": args.title,
+            "authors": [a.strip() for a in args.authors.split(",") if a.strip()],
+            "affiliations": [a.strip() for a in args.affiliations.split(",") if a.strip()],
+            "abstract": args.abstract,
+            "methods": [],
+            "datasets": [],
+            "metrics": [],
+        }
+        if args.details:
+            entry.update(load_details(args.details))
+        db.add(entry)
+        print("Entry added.")
+    elif args.command == "edit":
+        updates: Dict[str, Any] = {}
+        if args.title:
+            updates["title"] = args.title
+        if args.authors:
+            updates["authors"] = [a.strip() for a in args.authors.split(",") if a.strip()]
+        if args.affiliations:
+            updates["affiliations"] = [a.strip() for a in args.affiliations.split(",") if a.strip()]
+        if args.abstract:
+            updates["abstract"] = args.abstract
+        if args.details:
+            updates.update(load_details(args.details))
+        db.edit(args.index, updates)
+        print("Entry updated.")
+    elif args.command == "delete":
+        db.delete(args.index)
+        print("Entry deleted.")
+    elif args.command == "list":
+        for i, e in enumerate(db.list()):
+            print(f"[{i}] {e['title']}")
+    elif args.command == "fields":
+        print(json.dumps(db.list_fields(), indent=2))
+    elif args.command == "filter":
+        results = db.filter(model=args.model, dataset=args.dataset, metric=args.metric)
+        print(json.dumps(results, indent=2, ensure_ascii=False))
+    else:
+        parser.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/manuscripts.py
+++ b/manuscripts.py
@@ -1,0 +1,113 @@
+import json
+import os
+from typing import List, Dict, Any, Optional
+
+DB_PATH = "manuscripts.json"
+
+class ManuscriptDB:
+    """Simple JSON file based database for manuscripts."""
+
+    def __init__(self, path: str = DB_PATH) -> None:
+        self.path = path
+        self.data: List[Dict[str, Any]] = self._load()
+
+    def _load(self) -> List[Dict[str, Any]]:
+        if os.path.exists(self.path):
+            with open(self.path, "r", encoding="utf-8") as f:
+                content = f.read().strip()
+                if content:
+                    return json.loads(content)
+        return []
+
+    def _save(self) -> None:
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(self.data, f, indent=2, ensure_ascii=False)
+
+    # CRUD operations
+    def add(self, entry: Dict[str, Any]) -> None:
+        self.data.append(entry)
+        self._save()
+
+    def edit(self, index: int, updates: Dict[str, Any]) -> None:
+        if index < 0 or index >= len(self.data):
+            raise IndexError("Entry index out of range")
+        self.data[index].update(updates)
+        self._save()
+
+    def delete(self, index: int) -> None:
+        if index < 0 or index >= len(self.data):
+            raise IndexError("Entry index out of range")
+        self.data.pop(index)
+        self._save()
+
+    def list(self) -> List[Dict[str, Any]]:
+        return self.data
+
+    def list_fields(self) -> Dict[str, List[str]]:
+        models, datasets, metrics = set(), set(), set()
+        for entry in self.data:
+            for m in entry.get("methods", []):
+                name = m.get("model_name")
+                if name:
+                    models.add(name)
+            for d in entry.get("datasets", []):
+                name = d.get("name")
+                if name:
+                    datasets.add(name)
+            for mt in entry.get("metrics", []):
+                name = mt.get("name")
+                if name:
+                    metrics.add(name)
+        return {
+            "models": sorted(models),
+            "datasets": sorted(datasets),
+            "metrics": sorted(metrics),
+        }
+
+    def filter(self,
+               model: Optional[str] = None,
+               dataset: Optional[str] = None,
+               metric: Optional[str] = None) -> List[Dict[str, Any]]:
+        results = []
+        for entry in self.data:
+            match = True
+            if model and not any(m.get("model_name") == model for m in entry.get("methods", [])):
+                match = False
+            if dataset and not any(d.get("name") == dataset for d in entry.get("datasets", [])):
+                match = False
+            if metric and not any(mt.get("name") == metric for mt in entry.get("metrics", [])):
+                match = False
+            if match:
+                results.append(entry)
+        return results
+
+def generate_prompt() -> str:
+    """Return JSON string prompt for extracting manuscript details via ChatGPT."""
+    prompt = {
+        "instruction": "Given the text of an academic manuscript, extract structured information.",
+        "fields": {
+            "methods": [{
+                "model_name": "",
+                "type": "LLM | VLM | Image",
+                "embedding_size": "integer",
+                "backbone": "",
+                "parameters": "integer"
+            }],
+            "datasets": [{
+                "name": "",
+                "usage": "training | finetuning | evaluation",
+                "focus": "main purpose or domain",
+                "sample_type": "QA pair | long text | medical EHR | report | other",
+                "is_public": "true | false",
+                "num_samples": "integer"
+            }],
+            "metrics": [{
+                "name": "",
+                "evaluation_type": "multiple choice | QA | other",
+                "value": "number",
+                "description": "how the metric is calculated",
+                "model_name": "associated model"
+            }]
+        }
+    }
+    return json.dumps(prompt, indent=2)

--- a/tests/test_manuscripts.py
+++ b/tests/test_manuscripts.py
@@ -1,0 +1,57 @@
+import json
+import tempfile
+from manuscripts import ManuscriptDB, generate_prompt
+
+
+def test_add_edit_delete():
+    with tempfile.NamedTemporaryFile() as tmp:
+        db = ManuscriptDB(tmp.name)
+        db.add({
+            "title": "Paper",
+            "authors": ["A"],
+            "affiliations": ["Org"],
+            "abstract": "",
+            "methods": [],
+            "datasets": [],
+            "metrics": [],
+        })
+        assert len(db.list()) == 1
+        db.edit(0, {"title": "New"})
+        assert db.list()[0]["title"] == "New"
+        db.delete(0)
+        assert db.list() == []
+
+
+def test_filter_and_fields():
+    with tempfile.NamedTemporaryFile() as tmp:
+        db = ManuscriptDB(tmp.name)
+        db.add({
+            "title": "P1",
+            "authors": [],
+            "affiliations": [],
+            "abstract": "",
+            "methods": [{"model_name": "M1"}],
+            "datasets": [{"name": "D1"}],
+            "metrics": [{"name": "Acc"}],
+        })
+        db.add({
+            "title": "P2",
+            "authors": [],
+            "affiliations": [],
+            "abstract": "",
+            "methods": [{"model_name": "M2"}],
+            "datasets": [{"name": "D2"}],
+            "metrics": [{"name": "F1"}],
+        })
+        assert db.filter(model="M1")[0]["title"] == "P1"
+        fields = db.list_fields()
+        assert "M2" in fields["models"]
+        assert "D2" in fields["datasets"]
+        assert "F1" in fields["metrics"]
+
+
+def test_generate_prompt_json():
+    data = json.loads(generate_prompt())
+    assert "methods" in data["fields"]
+    assert "datasets" in data["fields"]
+    assert "metrics" in data["fields"]


### PR DESCRIPTION
## Summary
- add JSON-file database and filtering utilities for manuscripts
- provide CLI to add, edit, delete and list entries and generate a structured ChatGPT prompt
- document usage and include tests for core operations

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a2fb7b1588332ab6ebb713d01cb4e